### PR TITLE
Do not turn off backlight, while typing

### DIFF
--- a/firmware/application/event_m0.cpp
+++ b/firmware/application/event_m0.cpp
@@ -343,6 +343,8 @@ void EventDispatcher::handle_encoder() {
 }
 
 void EventDispatcher::handle_touch() {
+	portapack::bl_tick_counter = 0;
+
 	touch_manager.feed(get_touch_frame());
 }
 


### PR DESCRIPTION
Touch event does not delay automatic backlight off